### PR TITLE
Fix lib symlinks

### DIFF
--- a/www/nodejs-project/app/lib
+++ b/www/nodejs-project/app/lib
@@ -1,1 +1,0 @@
-../../../ezra-bible-app/app/lib

--- a/www/nodejs-project/app/lib/language_mapper.js
+++ b/www/nodejs-project/app/lib/language_mapper.js
@@ -1,0 +1,1 @@
+../../../../ezra-bible-app/app/lib/language_mapper.js

--- a/www/nodejs-project/app/lib/platform_helper.js
+++ b/www/nodejs-project/app/lib/platform_helper.js
@@ -1,0 +1,1 @@
+../../../../ezra-bible-app/app/lib/platform_helper.js


### PR DESCRIPTION
Create symlinks to the files instead of `lib` directory, thus avoid copy of the `__tests__` folder