### PR TITLE
Docker build env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN rm /root/${GRADLE_ZIP}
 ENV PATH=${PATH}:/usr/local/gradle-6.7.1/bin
 
 # Install some standard tools
-RUN apt-get install -y git vim curl sudo python build-essential cmake
+RUN apt-get install -y git vim curl sudo python build-essential cmake subversion
 
 # Install nodejs
 RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM ubuntu:20.04
 # You must have these available in the local folder with exactly these filenames!
 ENV JDK_TAR_FILE=jdk-8u301-linux-x64.tar.gz
 ENV ANDROID_TOOLS_ZIP=commandlinetools-linux-7583922_latest.zip
+ENV ANDROID_NDK_ZIP=android-ndk-r22-linux-x86_64.zip
+ENV ANDROID_NDK_FOLDER=android-ndk-r22
+
 # Android API level 29 => Android 10
 ENV ANDROID_API_LEVEL=29
 
@@ -12,6 +15,8 @@ ENV ANDROID_API_LEVEL=29
 
 ENV JAVA_HOME=/usr/local/jdk1.8.0_301
 ENV ANDROID_SDK_ROOT=/usr/local/android_sdk_root
+ENV ANDROID_HOME=${ANDROID_SDK_ROOT}
+ENV ANDROID_NDK_HOME=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_FOLDER}
 
 # Install Java JDK
 COPY ${JDK_TAR_FILE} /root
@@ -34,3 +39,8 @@ RUN yes | sdkmanager --licenses
 
 # Install latest platform tools and the SDK tools for the respective API level
 RUN sdkmanager "platform-tools" "platforms;android-${ANDROID_API_LEVEL}"
+
+# Install Android NDK
+COPY ${ANDROID_NDK_ZIP} /root
+RUN mkdir -p ${ANDROID_SDK_ROOT}/ndk && cd ${ANDROID_SDK_ROOT}/ndk && unzip /root/${ANDROID_NDK_ZIP}
+RUN rm /root/${ANDROID_NDK_ZIP}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV JDK_TAR_FILE=jdk-8u301-linux-x64.tar.gz
 ENV ANDROID_TOOLS_ZIP=commandlinetools-linux-7583922_latest.zip
 ENV ANDROID_NDK_ZIP=android-ndk-r22-linux-x86_64.zip
 ENV ANDROID_NDK_FOLDER=android-ndk-r22
+ENV GRADLE_ZIP=gradle-6.7.1-bin.zip
 
 # Android API level 29 => Android 10
 ENV ANDROID_API_LEVEL=29
@@ -40,8 +41,31 @@ RUN yes | sdkmanager --licenses
 
 # Install latest platform tools and the SDK tools for the respective API level
 RUN sdkmanager "platform-tools" "platforms;android-${ANDROID_API_LEVEL}"
+RUN sdkmanager "build-tools;29.0.3"
 
 # Install Android NDK
 COPY ${ANDROID_NDK_ZIP} /root
 RUN mkdir -p ${ANDROID_SDK_ROOT}/ndk && cd ${ANDROID_SDK_ROOT}/ndk && unzip /root/${ANDROID_NDK_ZIP}
 RUN rm /root/${ANDROID_NDK_ZIP}
+
+# Install Gradle
+COPY ${GRADLE_ZIP} /root
+RUN cd /usr/local && unzip /root/${GRADLE_ZIP}
+RUN rm /root/${GRADLE_ZIP}
+ENV PATH=${PATH}:/usr/local/gradle-6.7.1/bin
+
+# Install some standard tools
+RUN apt-get install -y git vim curl sudo
+
+# Install nodejs
+RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
+RUN apt-get update
+RUN apt-get install -y nodejs
+
+# Install node 14.17.5
+RUN npm install -g n
+RUN n 14.17.5
+
+# Install Cordova
+RUN npm install -g cordova@7.0.0
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-### INPUTS ###
+############### INPUTS ################
 
 # NDK can be downloaded from here:
 # https://androidsdkoffline.blogspot.com/p/android-ndk-side-by-side-direct-download.html
@@ -15,7 +15,7 @@ ENV GRADLE_ZIP=gradle-6.7.1-bin.zip
 # Android API level 29 => Android 10
 ENV ANDROID_API_LEVEL=29
 
-##############
+#######################################
 
 ENV JAVA_HOME=/usr/local/jdk1.8.0_301
 ENV ANDROID_SDK_ROOT=/usr/local/android_sdk_root
@@ -61,7 +61,7 @@ RUN rm /root/${GRADLE_ZIP}
 ENV PATH=${PATH}:/usr/local/gradle-6.7.1/bin
 
 # Install some standard tools
-RUN apt-get install -y git vim curl sudo python build-essential
+RUN apt-get install -y git vim curl sudo python build-essential cmake
 
 # Install nodejs
 RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:20.04
+
+### INPUTS ###
+
+# You must have these available in the local folder with exactly these filenames!
+ENV JDK_TAR_FILE=jdk-8u301-linux-x64.tar.gz
+ENV ANDROID_TOOLS_ZIP=commandlinetools-linux-7583922_latest.zip
+# Android API level 29 => Android 10
+ENV ANDROID_API_LEVEL=29
+
+##############
+
+ENV JAVA_HOME=/usr/local/jdk1.8.0_301
+ENV ANDROID_SDK_ROOT=/usr/local/android_sdk_root
+
+# Install Java JDK
+COPY ${JDK_TAR_FILE} /root
+RUN cd /usr/local && tar xvfz /root/${JDK_TAR_FILE}
+RUN rm /root/${JDK_TAR_FILE}
+
+RUN apt update
+RUN apt install unzip
+
+# Install android SDK tools
+COPY ${ANDROID_TOOLS_ZIP} /root
+RUN mkdir -p /usr/local/android_sdk_root/cmdline-tools
+RUN cd ${ANDROID_SDK_ROOT}/cmdline-tools && unzip /root/${ANDROID_TOOLS_ZIP} && mv cmdline-tools tools
+RUN rm /root/${ANDROID_TOOLS_ZIP}
+
+ENV PATH=${PATH}:${JAVA_HOME}/bin:${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin
+
+# Accept all SDK Manager licenses
+RUN yes | sdkmanager --licenses
+
+# Install latest platform tools and the SDK tools for the respective API level
+RUN sdkmanager "platform-tools" "platforms;android-${ANDROID_API_LEVEL}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:20.04
 
 ### INPUTS ###
 
+# NDK can be downloaded from here: https://androidsdkoffline.blogspot.com/p/android-ndk-side-by-side-direct-download.html
 # You must have these available in the local folder with exactly these filenames!
 ENV JDK_TAR_FILE=jdk-8u301-linux-x64.tar.gz
 ENV ANDROID_TOOLS_ZIP=commandlinetools-linux-7583922_latest.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM debian:bullseye-slim
-#FROM ubuntu:20.04
 
 ### INPUTS ###
 
@@ -51,6 +50,9 @@ RUN sdkmanager "cmake;3.6.4111459"
 COPY ${ANDROID_NDK_ZIP} /root
 RUN mkdir -p ${ANDROID_SDK_ROOT}/ndk && cd ${ANDROID_SDK_ROOT}/ndk && unzip /root/${ANDROID_NDK_ZIP}
 RUN rm /root/${ANDROID_NDK_ZIP}
+# Create symlinks to fix things up for mips64el-linux-android and mipsel-linux-android
+RUN cd ${ANDROID_NDK_HOME}/toolchains && ln -s aarch64-linux-android-4.9 mips64el-linux-android
+RUN cd ${ANDROID_NDK_HOME}/toolchains && ln -s arm-linux-androideabi-4.9 mipsel-linux-android
 
 # Install Gradle
 COPY ${GRADLE_ZIP} /root
@@ -72,6 +74,5 @@ RUN n 14.17.5
 
 # Install Cordova
 RUN npm install -g cordova@7.1.0
-RUN npm install -g cordova-android@6.4.0
 RUN cordova telemetry off
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM ubuntu:20.04
+FROM debian:bullseye-slim
+#FROM ubuntu:20.04
 
 ### INPUTS ###
 
-# NDK can be downloaded from here: https://androidsdkoffline.blogspot.com/p/android-ndk-side-by-side-direct-download.html
+# NDK can be downloaded from here:
+# https://androidsdkoffline.blogspot.com/p/android-ndk-side-by-side-direct-download.html
+# r21b: https://dl.google.com/android/repository/android-ndk-r21b-linux-x86_64.zip
 # You must have these available in the local folder with exactly these filenames!
 ENV JDK_TAR_FILE=jdk-8u301-linux-x64.tar.gz
 ENV ANDROID_TOOLS_ZIP=commandlinetools-linux-7583922_latest.zip
-ENV ANDROID_NDK_ZIP=android-ndk-r22-linux-x86_64.zip
-ENV ANDROID_NDK_FOLDER=android-ndk-r22
+ENV ANDROID_NDK_ZIP=android-ndk-r21b-linux-x86_64.zip
+ENV ANDROID_NDK_FOLDER=android-ndk-r21b
 ENV GRADLE_ZIP=gradle-6.7.1-bin.zip
 
 # Android API level 29 => Android 10
@@ -41,7 +44,8 @@ RUN yes | sdkmanager --licenses
 
 # Install latest platform tools and the SDK tools for the respective API level
 RUN sdkmanager "platform-tools" "platforms;android-${ANDROID_API_LEVEL}"
-RUN sdkmanager "build-tools;29.0.3"
+RUN sdkmanager "build-tools;30.0.3"
+RUN sdkmanager "cmake;3.6.4111459"
 
 # Install Android NDK
 COPY ${ANDROID_NDK_ZIP} /root
@@ -55,7 +59,7 @@ RUN rm /root/${GRADLE_ZIP}
 ENV PATH=${PATH}:/usr/local/gradle-6.7.1/bin
 
 # Install some standard tools
-RUN apt-get install -y git vim curl sudo
+RUN apt-get install -y git vim curl sudo python build-essential
 
 # Install nodejs
 RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
@@ -67,5 +71,7 @@ RUN npm install -g n
 RUN n 14.17.5
 
 # Install Cordova
-RUN npm install -g cordova@7.0.0
+RUN npm install -g cordova@7.1.0
+RUN npm install -g cordova-android@6.4.0
+RUN cordova telemetry off
 

--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -1,7 +1,7 @@
 ext.cdvMinSdkVersion=21
 ext.cdvCompileSdkVersion=29
 ext.cdvTargetSdkVersion=29
-ext.cdvReleaseSigningPropertiesFile="../../release-signing.properties"
+// ext.cdvReleaseSigningPropertiesFile="../../release-signing.properties"
 
 ext.postBuildExtras = {
     android.defaultConfig.ndk.abiFilters = ['armeabi-v7a', 'arm64-v8a']


### PR DESCRIPTION
Based on the Dockerfile added by this PR I was able to perform a build.

@zhuiks Feel free to give it a try.

You will need to first download the following files and put them in the working directory under the cloned repo:
* jdk-8u301-linux-x64.tar.gz
* commandlinetools-linux-7583922_latest.zip
* android-ndk-r21b-linux-x86_64.zip
* gradle-6.7.1-bin.zip

Note that particularly the Android NDK version is mandatory (requirement described by nodejs-mobile).

If you want to use this based on how it is now:
1. Download the above mentioned files
2. Install Docker. Should be `apt-get install docker.io`
3. Build a docker image. Run `docker build -t ezra-cordova .` (Note the `.` at the end) in the cloned repo working dir.
4. Run the docker image. Run `docker run -it ezra-cordova bash`
5. Clone `ezra-bible-app-cordova` (including submodules init & update) and run the build.

Open points:
* [ ] Create script for building based on the respective Docker container
* [ ] Dynamically handle release signing properties file
* [ ] Document binary signing procedure